### PR TITLE
Allow File::Temp handles to be guessed correctly

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,6 +12,10 @@ WriteMakefile(
     LICENSE => "perl",
     MIN_PERL_VERSION => 5.006002,
     PREREQ_PM => {
+        "Scalar::Util" => 0,
+        "Carp" => 0,
+        "Test::More" => "0.96",
+        "Test::Exception" => 0,
     },
     META_MERGE => {
 	resources => {

--- a/lib/LWP/MediaTypes.pm
+++ b/lib/LWP/MediaTypes.pm
@@ -7,6 +7,8 @@ require Exporter;
 $VERSION = "6.02";
 
 use strict;
+use Scalar::Util qw(blessed);
+use Carp qw(croak);
 
 # note: These hashes will also be filled with the entries found in
 # the 'media.types' file.
@@ -47,10 +49,17 @@ sub guess_media_type
     return undef unless defined $file;
 
     my $fullname;
-    if (ref($file)) {
-	# assume URI object
-	$file = $file->path;
-	#XXX should handle non http:, file: or ftp: URIs differently
+    if (ref $file) {
+        croak("Unable to determine filetype on unblessed refs") unless blessed($file);
+        if ($file->can('path')) {
+            $file = $file->path;
+        }
+        elsif ($file->can('filename')) {
+            $fullname = $file->filename;
+        }
+        else {
+            $fullname = "" . $file;
+        }
     }
     else {
 	$fullname = $file;  # enable peek at actual file
@@ -214,9 +223,12 @@ The following functions are exported by default:
 
 =item guess_media_type( $uri )
 
-=item guess_media_type( $filename_or_uri, $header_to_modify )
+=item guess_media_type( $filename_or_object, $header_to_modify )
 
-This function tries to guess media type and encoding for a file or a URI.
+This function tries to guess media type and encoding for a file or objects that
+support the a C<path> or C<filename> method, eg, L<URI> or L<File::Temp> objects.
+When an object does not support either method, it will be stringified to
+determine the filename.
 It returns the content type, which is a string like C<"text/html">.
 In array context it also returns any content encodings applied (in the
 order used to encode the file).  You can pass a URI object

--- a/t/mediatypes.t
+++ b/t/mediatypes.t
@@ -1,7 +1,8 @@
 #!perl -w
 
 use strict;
-use Test;
+use Test::More;
+use Test::Exception;
 
 use LWP::MediaTypes;
 
@@ -10,22 +11,24 @@ my $url2 = URI->new('http:test');
 
 my $file = "./README";
 
-my @tests =
-(
- ["/this.dir/file.html" => "text/html",],
- ["test.gif.htm"        => "text/html",],
- ["test.txt.gz"         => "text/plain", "gzip"],
- ["gif.foo"             => "application/octet-stream",],
- ["lwp-0.03.tar.Z"      => "application/x-tar", "compress"],
- [$file		        => "text/plain",],
- ["/random/file"        => "application/octet-stream",],
- [($^O eq 'VMS'? "nl:" : "/dev/null") => "text/plain",],
- [$url1	        	=> "image/gif",],
- [$url2	        	=> "application/octet-stream",],
- ["x.ppm.Z.UU"		=> "image/x-portable-pixmap","compress","x-uuencode",],
-);
+my $nocando = TestNoCanDo->new();
+my $fh = TestFileTemp->new();
 
-plan tests => @tests * 3 + 6;
+my @tests = (
+    ["/this.dir/file.html" => "text/html",],
+    ["test.gif.htm"        => "text/html",],
+    ["test.txt.gz"         => "text/plain", "gzip"],
+    ["gif.foo"             => "application/octet-stream",],
+    ["lwp-0.03.tar.Z"      => "application/x-tar", "compress"],
+    [$file                 => "text/plain",],
+    ["/random/file"        => "application/octet-stream",],
+    [($^O eq 'VMS' ? "nl:" : "/dev/null") => "text/plain",],
+    [$url1 => "image/gif",],
+    [$url2 => "application/octet-stream",],
+    ["x.ppm.Z.UU" => "image/x-portable-pixmap", "compress", "x-uuencode",],
+    [$fh          => "text/plain",],
+    [$nocando     => "text/plain",],
+);
 
 if ($ENV{HOME} and -f "$ENV{HOME}/.mime.types") {
    warn "
@@ -39,26 +42,34 @@ for (@tests) {
     my($file, $expectedtype, @expectedEnc) = @$_;
     my $type1 = guess_media_type($file);
     my($type, @enc) = guess_media_type($file);
-    ok($type1, $type);
-    ok($type, $expectedtype);
-    ok("@enc", "@expectedEnc");
+    is($type1, $type);
+    is($type, $expectedtype);
+    is("@enc", "@expectedEnc");
 }
 
+throws_ok(
+    sub {
+        guess_media_type({});
+    },
+    qr/Unable to determine filetype on unblessed refs/,
+    "Cannot pass unblessed refs"
+);
+
 my @imgSuffix = media_suffix('image/*');
-print "# Image suffixes: @imgSuffix\n";
+note "Image suffixes: @imgSuffix";
 ok(grep $_ eq "gif", @imgSuffix);
 
 my @audioSuffix = media_suffix('AUDIO/*');
-print "# Audio suffixes: @audioSuffix\n";
+note "Audio suffixes: @audioSuffix";
 ok(grep $_ eq 'oga', @audioSuffix);
-ok(media_suffix('audio/OGG'), 'oga');
+is(media_suffix('audio/OGG'), 'oga');
 
 my $r = Headers->new;
 guess_media_type("file.tar.gz.uu", $r);
-ok($r->header("Content-Type"), "application/x-tar");
+is($r->header("Content-Type"), "application/x-tar");
 
 my @enc = $r->header("Content-Encoding");
-ok("@enc", "gzip x-uuencode");
+is("@enc", "gzip x-uuencode");
 
 #
 use LWP::MediaTypes qw(add_type add_encoding);
@@ -68,10 +79,11 @@ add_encoding(rot13 => "r13");
 
 my @x = guess_media_type("foo.vrml.r13.gz");
 #print "@x\n";
-ok("@x", "x-world/x-vrml rot13 x-gzip");
+is("@x", "x-world/x-vrml rot13 x-gzip");
 
 #print LWP::MediaTypes::_dump();
 
+done_testing();
 
 BEGIN {
     # mockups
@@ -107,5 +119,30 @@ BEGIN {
 	}
 	return $old;
     }
+
+    package TestNoCanDo;
+
+    sub new {
+        my $class = shift;
+        return bless {}, $class;
+    }
+
+    sub to_string {
+        return "./README"
+    }
+
+    use overload '""' => 'to_string';
+
+    package TestFileTemp;
+
+    sub new {
+        my $class = shift;
+        return bless {}, $class;
+    }
+
+    sub filename {
+        return "./README"
+    }
+
 }
 


### PR DESCRIPTION
The previous implementation only allowed URI objects to be guessed
correctly. This changeset implements `$file->can('')` so we can deal
with other kind of objects as well. If an object cannot `path()` or
`filename()` we stringify the object as a last resort.